### PR TITLE
Handle array inputs in file manager helper

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,6 +7,8 @@ use Request;
 use Illuminate\Support\Facades\View;
 use App\Models\Category;
 use App\Models\GeneralSetting;
+use App\Support\CustomLfm;
+use UniSharp\LaravelFilemanager\Lfm;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -17,7 +19,13 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        // Override the default Filemanager helper so we can customize
+        // how request input is translated. The stock implementation
+        // fails when an array is passed (e.g. moving multiple files).
+        // Binding our extension ensures all package controllers use it.
+        $this->app->bind(Lfm::class, function ($app) {
+            return new CustomLfm($app['config'], $app['request']);
+        });
     }
 
     /**

--- a/app/Support/CustomLfm.php
+++ b/app/Support/CustomLfm.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Support;
+
+use UniSharp\LaravelFilemanager\Lfm;
+
+class CustomLfm extends Lfm
+{
+    /**
+     * Override parent to support array inputs without errors.
+     *
+     * @param  mixed  $input
+     * @return mixed
+     */
+    public function translateFromUtf8($input)
+    {
+        if (is_array($input)) {
+            return array_map(function ($value) {
+                return $this->translateFromUtf8($value);
+            }, $input);
+        }
+
+        if (! is_string($input)) {
+            return $input;
+        }
+
+        if ($this->isRunningOnWindows()) {
+            $input = iconv('UTF-8', mb_detect_encoding($input), $input);
+        }
+
+        return $input;
+    }
+}

--- a/tests/Unit/LfmInputTest.php
+++ b/tests/Unit/LfmInputTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Config\Repository;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
+use App\Support\CustomLfm;
+
+class LfmInputTest extends TestCase
+{
+    public function test_translate_from_utf8_handles_array_input(): void
+    {
+        $request = Request::create('/', 'GET', [
+            'items' => ['file1.txt', 'file2.txt'],
+        ]);
+        $config = new Repository(['lfm' => []]);
+        $lfm = new CustomLfm($config, $request);
+
+        $result = $lfm->input('items');
+
+        $this->assertSame(['file1.txt', 'file2.txt'], $result);
+    }
+}


### PR DESCRIPTION
## Summary
- add `CustomLfm` to safely translate array inputs
- bind `CustomLfm` in the service provider
- cover helper with unit test

## Testing
- `APP_KEY=base64:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa= ./vendor/bin/phpunit --testsuite Unit`
- `APP_KEY=base64:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa= ./vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_6891ee4c068483279c49a85915c6b1e5